### PR TITLE
fix: remove eslint blog from DB

### DIFF
--- a/db/changelogUrls.json
+++ b/db/changelogUrls.json
@@ -1,7 +1,6 @@
 {
     "bluebird": "http://bluebirdjs.com/docs/changelog.html",
     "browserify": "https://github.com/substack/node-browserify/blob/master/changelog.markdown",
-    "eslint": "http://eslint.org/blog/",
     "fluxible": "https://github.com/yahoo/fluxible/blob/master/packages/fluxible/CHANGELOG.md",
     "lodash": "https://github.com/lodash/lodash/wiki/Changelog"
 }


### PR DESCRIPTION
https://github.com/eslint/eslint/blob/master/CHANGELOG.md exists now, and should be picked up by default.

(as first brought up [here](https://twitter.com/tivac/status/1093196078478848000), and then PR requested [here](https://twitter.com/grunin_ya/status/1093199701875351553))