### PR TITLE
WIP:  Create separate commits per upgraded package

### DIFF
--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -241,7 +241,7 @@ export const handler = catchAsyncError(async opts => {
         // Assume yarn for now
         execSync('yarn',{stdio: 'inherit'})
         execSync('git add package.json yarn.lock',{stdio: 'inherit'})
-        execSync(`git commit -m "Upgraded ${name} from ${from} to ${to}"`,{stdio: 'inherit'})
+        execSync(`git commit -m "Upgrade ${name} from ${from} to ${to}"`,{stdio: 'inherit'})
         break;
 
       case true:

--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -254,6 +254,8 @@ export const handler = catchAsyncError(async opts => {
             execSync('git add package.json', {stdio: 'inherit'})
           }
           execSync(`git commit -m "Upgrade ${name} from ${from} to ${to}"`,{stdio: 'inherit'})
+          // Clean the list of packages to be updated after updating and commiting 
+          updatedModules.splice(0, updatedModules.length);
         } catch(err) {
           console.error(err)
         }

--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -242,7 +242,7 @@ export const handler = catchAsyncError(async opts => {
 
         // execSync('npm i',{stdio: 'inherit'})
         execSync('git add package.json',{stdio: 'inherit'})
-        execSync(`git commit -m "Upgraded ${outdatedModule}"`,{stdio: 'inherit'})
+        execSync(`git commit -m "Upgraded ${name} from ${from} to ${to}"`,{stdio: 'inherit'})
         break;
 
       case true:

--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -154,8 +154,8 @@ export const handler = catchAsyncError(async opts => {
       message: `${changelogUrl === undefined ? 'U' : 'So, u'}pdate "${name}" in package.json ` +
       `from ${from} to ${colorizeDiff(from, to)}?`,
       choices: _.compact([
-        {name: 'Yes and create a separate commit', value: 'commit'},
         {name: 'Yes', value: true},
+        {name: 'Yes and create a separate commit', value: 'commit'},
         {name: 'No', value: false},
         // Don't show this option if we couldn't find module's changelog url
         (changelogUrl !== null) &&

--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -155,7 +155,7 @@ export const handler = catchAsyncError(async opts => {
       `from ${from} to ${colorizeDiff(from, to)}?`,
       choices: _.compact([
         {name: 'Yes', value: true},
-        {name: 'Yes and create a separate commit', value: 'commit'},
+        {name: 'Update immediately and create a separate commit', value: 'commit'},
         {name: 'No', value: false},
         // Don't show this option if we couldn't find module's changelog url
         (changelogUrl !== null) &&
@@ -242,18 +242,18 @@ export const handler = catchAsyncError(async opts => {
         try {
           if (existsSync('yarn.lock')) {
             // Assume the user wants to use yarn
-            execSync('yarn', {stdio: 'inherit'})
-            execSync('git add package.json yarn.lock', {stdio: 'inherit'})
+            execSync('yarn', {stdio: 'inherit'});
+            execSync('git add package.json yarn.lock', {stdio: 'inherit'});
           } else if (existsSync('package-lock.json')) {
             // Use npm and package-lock.json
-            execSync('npm install', {stdio: 'inherit'})
-            execSync('git add package.json package-lock.json', {stdio: 'inherit'})
+            execSync('npm install', {stdio: 'inherit'});
+            execSync('git add package.json package-lock.json', {stdio: 'inherit'});
           } else {
             // Default to only using npm install and not including a lock file
-            execSync('npm install', {stdio: 'inherit'})
-            execSync('git add package.json', {stdio: 'inherit'})
+            execSync('npm install', {stdio: 'inherit'});
+            execSync('git add package.json', {stdio: 'inherit'});
           }
-          execSync(`git commit -m "Upgrade ${name} from ${from} to ${to}"`,{stdio: 'inherit'})
+          execSync(`git commit -m "Upgrade ${name} from ${from} to ${to}"`,{stdio: 'inherit'});
           // Clean the list of packages to be updated after updating and commiting 
           updatedModules.splice(0, updatedModules.length);
         } catch(err) {

--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -154,8 +154,8 @@ export const handler = catchAsyncError(async opts => {
       message: `${changelogUrl === undefined ? 'U' : 'So, u'}pdate "${name}" in package.json ` +
       `from ${from} to ${colorizeDiff(from, to)}?`,
       choices: _.compact([
-        {name: 'Yes', value: true},
         {name: 'Yes and create a separate commit', value: 'commit'},
+        {name: 'Yes', value: true},
         {name: 'No', value: false},
         // Don't show this option if we couldn't find module's changelog url
         (changelogUrl !== null) &&

--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -238,10 +238,9 @@ export const handler = catchAsyncError(async opts => {
           // Adding newline to the end of file
           `${JSON.stringify(packageJson, null, indent)}\n`
         );
-        console.log('NOW WE SHOULD COMMIT!');
-
-        // execSync('npm i',{stdio: 'inherit'})
-        execSync('git add package.json',{stdio: 'inherit'})
+        // Assume yarn for now
+        execSync('yarn',{stdio: 'inherit'})
+        execSync('git add package.json yarn.lock',{stdio: 'inherit'})
         execSync(`git commit -m "Upgraded ${name} from ${from} to ${to}"`,{stdio: 'inherit'})
         break;
 


### PR DESCRIPTION
Based on my suggestion in #37, here is a PR that implements that functionality.

This is still a bit of work in progress, but I wanted to open this PR in order to get feedback. I used this solution now for my project and it seems to be working well for my use case.

Here's the list of things to do:

- [ ] Introduce an option in .npm-upgrade.json which will store the name of the package manager used in current project. This option is not mandatory and may not be specified.
- [ ] If it present, use it. If it's not, goto 3.
- [x] Search for yarn.lock or package-lock.json files. If they present, use corresponding package manager (without setting an option in config file).
- [ ] If lock files are not there, ask user in commit phase about package manager and set it in the config.


Implements and closes #37 