### PR TITLE
Replace unmaintained 'opener' dependency with 'open' to fix URLs not opening on WSL2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4493,6 +4493,11 @@
         }
       }
     },
+    "is-docker": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
+      "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ=="
+    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -4634,6 +4639,14 @@
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
     },
     "is-yarn-global": {
       "version": "0.3.0",
@@ -5813,10 +5826,14 @@
         "mimic-fn": "^1.0.0"
       }
     },
-    "opener": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
-      "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA=="
+    "open": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.0.4.tgz",
+      "integrity": "sha512-brSA+/yq+b08Hsr4c8fsEW2CRzk1BmfN3SAK/5VCHQ9bdoZJ4qa/+AfR0xHjlbbZUyPkUHs1b8x1RqdyZdkVqQ==",
+      "requires": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      }
     },
     "optionator": {
       "version": "0.8.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "libnpmconfig": "1.2.1",
     "lodash": "4.17.14",
     "npm-check-updates": "4.0.3",
-    "opener": "1.5.1",
+    "open": "^7.0.4",
     "pacote": "9.5.4",
     "semver": "6.2.0",
     "yargs": "13.3.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "libnpmconfig": "1.2.1",
     "lodash": "4.17.14",
     "npm-check-updates": "4.0.3",
-    "open": "^7.0.4",
+    "open": "7.0.4",
     "pacote": "9.5.4",
     "semver": "6.2.0",
     "yargs": "13.3.0"

--- a/src/commands/changelog.js
+++ b/src/commands/changelog.js
@@ -1,4 +1,4 @@
-import opener from 'opener';
+import open from 'open';
 
 import catchAsyncError from '../catchAsyncError';
 import {findModuleChangelogUrl} from '../changelogUtils';
@@ -24,7 +24,7 @@ export const handler = catchAsyncError(async opts => {
 
   if (changelogUrl) {
     console.log(`Opening ${strong(changelogUrl)}...`);
-    opener(changelogUrl);
+    open(changelogUrl);
   } else {
     console.log(
       "Sorry, we haven't found any changelog URL for this module.\n" +

--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -2,7 +2,7 @@ import {writeFileSync} from 'fs';
 
 import _ from 'lodash';
 import {flow, map, partition} from 'lodash/fp';
-import opener from 'opener';
+import open from 'open';
 import semver from 'semver';
 import detectIndent from 'detect-indent';
 import ncu from 'npm-check-updates';
@@ -181,7 +181,7 @@ export const handler = catchAsyncError(async opts => {
 
         if (changelogUrl) {
           console.log(`Opening ${strong(changelogUrl)}...`);
-          opener(changelogUrl);
+          open(changelogUrl);
         } else {
           console.log(
             `Sorry, we haven't found any changelog URL for ${strong(name)} module.\n` +
@@ -202,7 +202,7 @@ export const handler = catchAsyncError(async opts => {
 
         if (homepage) {
           console.log(`Opening ${strong(homepage)}...`);
-          opener(homepage);
+          open(homepage);
         } else {
           console.log(`Sorry, there is no info about homepage URL in the ${strong(name)}'s package.json`);
         }


### PR DESCRIPTION
The [`opener`](https://www.npmjs.com/package/opener) package was last updated almost 2 years ago and I've been running into domenic/opener#33 for a while now when using npm-upgrade so I decided to look for a fix myself.

In this PR I've replaced it with [`open`](https://www.npmjs.com/package/open) (previously known as `opn`) which is still maintained and has more than twice as many weekly downloads.

I've been using these modifications for a couple of days without any problems locally.