### PR TITLE
Add changelog url for `@zxing/ngx-scanner`

### DIFF
--- a/db/changelogUrls.json
+++ b/db/changelogUrls.json
@@ -33,6 +33,7 @@
     "@testing-library/react": "https://github.com/testing-library/react-testing-library/releases",
     "@testing-library/react-hooks": "https://github.com/testing-library/react-hooks-testing-library/releases",
     "@testing-library/user-event": "https://github.com/testing-library/user-event/releases",
+    "@zxing/ngx-scanner": "https://github.com/zxing-js/ngx-scanner/releases",
     "bluebird": "http://bluebirdjs.com/docs/changelog.html",
     "browserify": "https://github.com/substack/node-browserify/blob/master/changelog.markdown",
     "fluxible": "https://github.com/yahoo/fluxible/blob/master/packages/fluxible/CHANGELOG.md",


### PR DESCRIPTION
Adding explicit changelog url for `@zxing/ngx-scanner` as it could not be found:
```
? Update "@zxing/ngx-scanner" in package.json from 3.8.0 to 3.8.1? Show changelog
Trying to find changelog URL...
Sorry, we haven't found any changelog URL for @zxing/ngx-scanner module.
It would be great if you could fill an issue about this here: https://github.com/th0r/npm-upgrade/issues
Thanks a lot!
```