### PR TITLE
Add changelog url for `cypress`

### DIFF
--- a/db/changelogUrls.json
+++ b/db/changelogUrls.json
@@ -35,6 +35,7 @@
     "@testing-library/user-event": "https://github.com/testing-library/user-event/releases",
     "bluebird": "http://bluebirdjs.com/docs/changelog.html",
     "browserify": "https://github.com/substack/node-browserify/blob/master/changelog.markdown",
+    "cypress": "https://on.cypress.io/changelog",
     "fluxible": "https://github.com/yahoo/fluxible/blob/master/packages/fluxible/CHANGELOG.md",
     "lodash": "https://github.com/lodash/lodash/wiki/Changelog",
     "vue-loader": "https://github.com/vuejs/vue-loader/releases"


### PR DESCRIPTION
Add explicit changelog url for cypress, because currently it links to cypress' [CHANGELOG.md](https://github.com/cypress-io/cypress/blob/master/CHANGELOG.md) that only contains a link to their real changelog page.

![image](https://user-images.githubusercontent.com/8677948/222701431-fcda4d0c-a30f-4700-bb70-bfdc0f791f5a.png)
