### PR TITLE
Add changelog url for 'libphonenumber-js'

### DIFF
--- a/db/changelogUrls.json
+++ b/db/changelogUrls.json
@@ -38,6 +38,7 @@
     "browserify": "https://github.com/substack/node-browserify/blob/master/changelog.markdown",
     "cypress": "https://on.cypress.io/changelog",
     "fluxible": "https://github.com/yahoo/fluxible/blob/master/packages/fluxible/CHANGELOG.md",
+    "libphonenumber-js": "https://gitlab.com/catamphetamine/libphonenumber-js/-/blob/master/CHANGELOG.md",
     "lodash": "https://github.com/lodash/lodash/wiki/Changelog",
     "vue-loader": "https://github.com/vuejs/vue-loader/releases"
 }


### PR DESCRIPTION
Adds a changelog url for https://www.npmjs.com/package/libphonenumber-js