### PR TITLE
add fastly changelog url

### DIFF
--- a/db/changelogUrls.json
+++ b/db/changelogUrls.json
@@ -37,6 +37,7 @@
     "bluebird": "http://bluebirdjs.com/docs/changelog.html",
     "browserify": "https://github.com/substack/node-browserify/blob/master/changelog.markdown",
     "cypress": "https://on.cypress.io/changelog",
+    "fastly": "https://github.com/fastly/fastly-js/blob/main/CHANGELOG.md",
     "fluxible": "https://github.com/yahoo/fluxible/blob/master/packages/fluxible/CHANGELOG.md",
     "lodash": "https://github.com/lodash/lodash/wiki/Changelog",
     "vue-loader": "https://github.com/vuejs/vue-loader/releases"


### PR DESCRIPTION
- Add correct [fastly changelog URL](https://github.com/fastly/fastly-js/blob/main/CHANGELOG.md)
- Requested in #93 